### PR TITLE
Ignore layer without fill (fix error)

### DIFF
--- a/code.js
+++ b/code.js
@@ -15,22 +15,26 @@ ref.sort(function (a, b) {
 ref.forEach((layer) => {
     // make sure it's a vector
     if (layer.type === "RECTANGLE" || layer.type === "ELLIPSE" || layer.type === "POLYGON" || layer.type === "VECTOR") {
-        if (!layer.fillStyleId) {
+        var fill = layer.fills[0];
+        if (!fill) {
+            // Just skip.
+        }
+        else if (!layer.fillStyleId) {
             //creating the paint style
             var newStyle = figma.createPaintStyle();
-            var hex = findTheHEX(layer.fills[0].color.r, layer.fills[0].color.g, layer.fills[0].color.b);
+            var hex = findTheHEX(fill.color.r, fill.color.g, fill.color.b);
             //naming the paint style with the layer name
             newStyle.name = layer.name;
             newStyle.description = hex.toUpperCase();
             //assigning the color
             newStyle.paints = [{
-                    type: layer.fills[0].type,
+                    type: fill.type,
                     color: {
-                        r: layer.fills[0].color.r,
-                        g: layer.fills[0].color.g,
-                        b: layer.fills[0].color.b
+                        r: fill.color.r,
+                        g: fill.color.g,
+                        b: fill.color.b
                     },
-                    opacity: layer.fills[0].opacity
+                    opacity: fill.opacity
                 }];
             //applying the style to the selected layer
             layer.fillStyleId = newStyle.id;

--- a/code.ts
+++ b/code.ts
@@ -20,12 +20,15 @@ ref.forEach((layer:any) => {
 
   // make sure it's a vector
   if (layer.type === "RECTANGLE" || layer.type === "ELLIPSE" || layer.type === "POLYGON" || layer.type === "VECTOR") {
+    var fill = layer.fills[0]
     
-    if(!layer.fillStyleId){
+    if (!fill) {
+      // Just skip.
+    } else if (!layer.fillStyleId) {
       
       //creating the paint style
       var newStyle = figma.createPaintStyle()
-      var hex = findTheHEX(layer.fills[0].color.r, layer.fills[0].color.g, layer.fills[0].color.b)
+      var hex = findTheHEX(fill.color.r, fill.color.g, fill.color.b)
 
       //naming the paint style with the layer name
       newStyle.name = layer.name
@@ -33,13 +36,13 @@ ref.forEach((layer:any) => {
 
       //assigning the color
       newStyle.paints = [{
-        type: layer.fills[0].type,
+        type: fill.type,
         color: {
-          r: layer.fills[0].color.r,
-          g: layer.fills[0].color.g,
-          b: layer.fills[0].color.b
+          r: fill.color.r,
+          g: fill.color.g,
+          b: fill.color.b
         },
-        opacity: layer.fills[0].opacity
+        opacity: fill.opacity
       }]
 
       //applying the style to the selected layer


### PR DESCRIPTION
When layer without fill color is selected, this plugin creates empty style and show error in console. This PR fixes it!

![image](https://user-images.githubusercontent.com/400558/81569430-389a2080-93da-11ea-8f75-366423b23bb7.png)

```
TypeError: value has no property
    at <anonymous> (PLUGIN_57_SOURCE:21)
    at forEach (native)
    at <anonymous> (PLUGIN_57_SOURCE:47)
    at call (native)
    at <eval> (PLUGIN_57_SOURCE:71)
```